### PR TITLE
add support for endpoint type 'VPC', remove support for endpoint_type…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,38 @@
 
 Creates a transfer server and tranfer users (with one or more public SSH keys).
 
-## Example
+## Example SFTP Server with Public endpoint
 ```
 module "example-transfer" {
-  source = "github.com/schubergphilis/terraform-aws-mcaf-transfer"
-  name   = "example"
-  tags   = {}
-  users  = {
+  name             = "example"
+  source           = "github.com/schubergphilis/terraform-aws-mcaf-transfer"
+  tags             = {}
+  users            = {
     user1 = {
       home_directory = "homedir1"
       role_policy    = null
       ssh_pub_keys   = ["key1", "key2"]
-  endpoint_type          = "VPC"
-  vpc_id                 = "vpc-123456"
-  address_allocation_ids = ["eipalloc-12345", "eipalloc-67890"]
-  subnet_ids             = ["subnet-12345", "subnet-67890"]
+    }
+  }
+}
+```
+## Example SFTP Server with VPC endpoint
+```
+module "example-transfer" {
+  endpoint_details = {
+    vpc_id                 = "vpc-123456"
+    address_allocation_ids = ["eipalloc-12345", "eipalloc-67890"]
+    subnet_ids             = ["subnet-12345", "subnet-67890"]
+  }
+  endpoint_type    = "VPC"
+  name             = "example"
+  source           = "github.com/schubergphilis/terraform-aws-mcaf-transfer"
+  tags             = {}
+  users            = {
+    user1 = {
+      home_directory = "homedir1"
+      role_policy    = null
+      ssh_pub_keys   = ["key1", "key2"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ module "example-transfer" {
       home_directory = "homedir1"
       role_policy    = null
       ssh_pub_keys   = ["key1", "key2"]
+  endpoint_type          = "VPC"
+  vpc_id                 = "vpc-123456"
+  address_allocation_ids = ["eipalloc-12345", "eipalloc-67890"]
+  subnet_ids             = ["subnet-12345", "subnet-67890"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ module "example-transfer" {
   name             = "example"
   endpoint_type    = "VPC"
   tags             = {}
-  
+
   endpoint_details = {
-    vpc_id                 = "vpc-123456"
     address_allocation_ids = ["eipalloc-12345", "eipalloc-67890"]
     subnet_ids             = ["subnet-12345", "subnet-67890"]
+    vpc_id                 = "vpc-123456"
   }
-  
-  users            = {
+
+  users = {
     user1 = {
       home_directory = "homedir1"
       role_policy    = null

--- a/README.md
+++ b/README.md
@@ -2,33 +2,20 @@
 
 Creates a transfer server and tranfer users (with one or more public SSH keys).
 
-## Example SFTP Server with Public endpoint
-```
-module "example-transfer" {
-  name             = "example"
-  source           = "github.com/schubergphilis/terraform-aws-mcaf-transfer"
-  tags             = {}
-  users            = {
-    user1 = {
-      home_directory = "homedir1"
-      role_policy    = null
-      ssh_pub_keys   = ["key1", "key2"]
-    }
-  }
-}
-```
 ## Example SFTP Server with VPC endpoint
 ```
 module "example-transfer" {
+  source           = "github.com/schubergphilis/terraform-aws-mcaf-transfer"
+  name             = "example"
+  endpoint_type    = "VPC"
+  tags             = {}
+  
   endpoint_details = {
     vpc_id                 = "vpc-123456"
     address_allocation_ids = ["eipalloc-12345", "eipalloc-67890"]
     subnet_ids             = ["subnet-12345", "subnet-67890"]
   }
-  endpoint_type    = "VPC"
-  name             = "example"
-  source           = "github.com/schubergphilis/terraform-aws-mcaf-transfer"
-  tags             = {}
+  
   users            = {
     user1 = {
       home_directory = "homedir1"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   endpoint_details = var.endpoint_details != null ? { create = true } : {}
   user_policy      = data.aws_iam_policy_document.user_policy.json
+
   user_ssh_keys = { for item in flatten([
     for user, config in var.users : [
       for index, ssh_key in config.ssh_pub_keys : {
@@ -17,6 +18,7 @@ data "aws_iam_policy_document" "user_policy" {
     actions = [
       "s3:*"
     ]
+
     resources = [
       "*"
     ]
@@ -28,6 +30,7 @@ data "aws_iam_policy_document" "assume_policy" {
     actions = [
       "sts:AssumeRole"
     ]
+
     principals {
       type        = "Service"
       identifiers = ["transfer.amazonaws.com"]
@@ -47,8 +50,8 @@ resource "aws_iam_role_policy_attachment" "server" {
 }
 
 resource "aws_transfer_server" "default" {
-  identity_provider_type = "SERVICE_MANAGED"
   endpoint_type          = upper(var.endpoint_type)
+  identity_provider_type = "SERVICE_MANAGED"
   logging_role           = aws_iam_role.server.arn
   tags                   = var.tags
 

--- a/main.tf
+++ b/main.tf
@@ -53,10 +53,12 @@ resource "aws_transfer_server" "default" {
   tags                   = var.tags
 
   dynamic "endpoint_details" {
-    for_each = var.vpc_endpoint_id != null ? list(1) : []
+    for_each = var.vpc_id != null ? list(1) : []
 
     content {
-      vpc_endpoint_id = var.vpc_endpoint_id
+      vpc_id                 = var.vpc_id
+      subnet_ids             = var.subnet_ids
+      address_allocation_ids = var.address_allocation_ids
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  endpoint_details = var.endpoint_details != null ? { create = true } : {}
-  user_policy      = data.aws_iam_policy_document.user_policy.json
+  user_policy  = data.aws_iam_policy_document.user_policy.json
+  vpc_endpoint = var.vpc_endpoint != null ? { create = true } : {}
 
   user_ssh_keys = { for item in flatten([
     for user, config in var.users : [
@@ -18,7 +18,6 @@ data "aws_iam_policy_document" "user_policy" {
     actions = [
       "s3:*"
     ]
-
     resources = [
       "*"
     ]
@@ -30,7 +29,6 @@ data "aws_iam_policy_document" "assume_policy" {
     actions = [
       "sts:AssumeRole"
     ]
-
     principals {
       type        = "Service"
       identifiers = ["transfer.amazonaws.com"]
@@ -50,18 +48,18 @@ resource "aws_iam_role_policy_attachment" "server" {
 }
 
 resource "aws_transfer_server" "default" {
-  endpoint_type          = upper(var.endpoint_type)
+  endpoint_type          = var.vpc_endpoint != null ? "VPC" : "PUBLIC"
   identity_provider_type = "SERVICE_MANAGED"
   logging_role           = aws_iam_role.server.arn
   tags                   = var.tags
 
   dynamic "endpoint_details" {
-    for_each = local.endpoint_details
+    for_each = local.vpc_endpoint
 
     content {
-      address_allocation_ids = var.endpoint_details.address_allocation_ids
-      subnet_ids             = var.endpoint_details.subnet_ids
-      vpc_id                 = var.endpoint_details.vpc_id
+      address_allocation_ids = var.vpc_endpoint.address_allocation_ids
+      subnet_ids             = var.vpc_endpoint.subnet_ids
+      vpc_id                 = var.vpc_endpoint.vpc_id
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
-  user_policy = data.aws_iam_policy_document.user_policy.json
-
+  endpoint_details = var.endpoint_details != null ? { create = true } : {}
+  user_policy      = data.aws_iam_policy_document.user_policy.json
   user_ssh_keys = { for item in flatten([
     for user, config in var.users : [
       for index, ssh_key in config.ssh_pub_keys : {
@@ -53,12 +53,12 @@ resource "aws_transfer_server" "default" {
   tags                   = var.tags
 
   dynamic "endpoint_details" {
-    for_each = var.vpc_id != null ? list(1) : []
+    for_each = local.endpoint_details
 
     content {
-      vpc_id                 = var.vpc_id
-      subnet_ids             = var.subnet_ids
-      address_allocation_ids = var.address_allocation_ids
+      address_allocation_ids = var.endpoint_details.address_allocation_ids
+      subnet_ids             = var.endpoint_details.subnet_ids
+      vpc_id                 = var.endpoint_details.vpc_id
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,3 @@
-variable "endpoint_details" {
-  type = object({
-    address_allocation_ids = list(string)
-    subnet_ids             = list(string)
-    vpc_id                 = string
-  })
-  default     = null
-  description = "VPC endpoint configuration, required when using endpoint type VPC (address_allocation_ids is optional)"
-}
-
-variable "endpoint_type" {
-  type        = string
-  default     = "PUBLIC"
-  description = "The endpoint type, can be VPC or PUBLIC"
-}
-
 variable "logging_policy" {
   type        = string
   default     = "arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"
@@ -37,4 +21,14 @@ variable "users" {
     ssh_pub_keys   = list(string)
   }))
   description = "A map with transfer users and configuration details"
+}
+
+variable "vpc_endpoint" {
+  type = object({
+    address_allocation_ids = list(string)
+    subnet_ids             = list(string)
+    vpc_id                 = string
+  })
+  default     = null
+  description = "Optional VPC endpoint settings for your SFTP server"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
-variable "name" {
-  type        = string
-  description = "A unique name for this transfer server instance"
+variable "address_allocation_ids" {
+  type        = list(string)
+  default     = null
+  description = "Optional Public Elastic IPs"
 }
 
 variable "endpoint_type" {
@@ -13,6 +14,17 @@ variable "logging_policy" {
   type        = string
   default     = "arn:aws:iam::aws:policy/service-role/AWSTransferLoggingAccess"
   description = "Default logging policy for the transfer server"
+}
+
+variable "name" {
+  type        = string
+  description = "A unique name for this transfer server instance"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  default     = null
+  description = "Optional Subnet IDs"
 }
 
 variable "tags" {
@@ -33,16 +45,4 @@ variable "vpc_id" {
   type        = string
   default     = null
   description = "An optional VPC ID"
-}
-
-variable "subnet_ids" {
-  type        = list(string)
-  default     = null
-  description = "Optional Subnet IDs"
-}
-
-variable "address_allocation_ids" {
-  type        = list(string)
-  default     = null
-  description = "Optional Public Elastic IPs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,8 +29,20 @@ variable "users" {
   description = "A map with transfer users and configuration details"
 }
 
-variable "vpc_endpoint_id" {
+variable "vpc_id" {
   type        = string
   default     = null
-  description = "An optional VPC endpoint ID"
+  description = "An optional VPC ID"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  default     = null
+  description = "Optional Subnet IDs"
+}
+
+variable "address_allocation_ids" {
+  type        = list(string)
+  default     = null
+  description = "Optional Public Elastic IPs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,11 @@
-variable "address_allocation_ids" {
-  type        = list(string)
+variable "endpoint_details" {
+  type = object({
+    vpc_id                 = string
+    subnet_ids             = list(string)
+    address_allocation_ids = list(string)
+  })
   default     = null
-  description = "Optional Public Elastic IPs"
+  description = "Variables needed when using endpoint_type VPC: VPC ID, Subnet ID, Public Elastic IP)"
 }
 
 variable "endpoint_type" {
@@ -21,12 +25,6 @@ variable "name" {
   description = "A unique name for this transfer server instance"
 }
 
-variable "subnet_ids" {
-  type        = list(string)
-  default     = null
-  description = "Optional Subnet IDs"
-}
-
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the resources"
@@ -39,10 +37,4 @@ variable "users" {
     ssh_pub_keys   = list(string)
   }))
   description = "A map with transfer users and configuration details"
-}
-
-variable "vpc_id" {
-  type        = string
-  default     = null
-  description = "An optional VPC ID"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,17 @@
 variable "endpoint_details" {
   type = object({
-    vpc_id                 = string
-    subnet_ids             = list(string)
     address_allocation_ids = list(string)
+    subnet_ids             = list(string)
+    vpc_id                 = string
   })
   default     = null
-  description = "Variables needed when using endpoint_type VPC: VPC ID, Subnet ID, Public Elastic IP)"
+  description = "VPC endpoint configuration, required when using endpoint type VPC (address_allocation_ids is optional)"
 }
 
 variable "endpoint_type" {
   type        = string
   default     = "PUBLIC"
-  description = "The endpoint type, can be VPC_ENDPOINT or PUBLIC"
+  description = "The endpoint type, can be VPC or PUBLIC"
 }
 
 variable "logging_policy" {


### PR DESCRIPTION
… 'VPC_ENDPOINT'. AWS is discontinuing the use of this, see https://docs.aws.amazon.com/transfer/latest/userguide/create-server-in-vpc.html#deprecate-vpc-endpoint