### PR TITLE
Add support for VPC Endpoint security group configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ module "example-transfer" {
   tags                     = {}
   transfer_security_policy = "TransferSecurityPolicy-2020-06"
 
-  endpoint_details = {
+  vpc_endpoint = {
+    security_group_ids     = ["sg-12345678901234567"]
     address_allocation_ids = ["eipalloc-12345", "eipalloc-67890"]
     subnet_ids             = ["subnet-12345", "subnet-67890"]
     vpc_id                 = "vpc-123456"

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ resource "aws_transfer_server" "default" {
     for_each = local.vpc_endpoint
 
     content {
+      security_group_ids     = var.vpc_endpoint.security_group_ids
       address_allocation_ids = var.vpc_endpoint.address_allocation_ids
       subnet_ids             = var.vpc_endpoint.subnet_ids
       vpc_id                 = var.vpc_endpoint.vpc_id

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,6 @@ variable "security_group_ids" {
   description = "Security group ID's for VPC endpoint."
 }
 
-
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the resources"

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,13 @@ variable "restricted_mode" {
   description = "Lock down all users to their home directory."
 }
 
+variable "security_group_ids" {
+  type        = list(string)
+  default     = null
+  description = "Security group ID's for VPC endpoint."
+}
+
+
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the resources"
@@ -49,6 +56,7 @@ variable "users" {
 
 variable "vpc_endpoint" {
   type = object({
+    security_group_ids     = list(string)
     address_allocation_ids = list(string)
     subnet_ids             = list(string)
     vpc_id                 = string

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,6 @@ variable "restricted_mode" {
   description = "Lock down all users to their home directory."
 }
 
-variable "security_group_ids" {
-  type        = list(string)
-  default     = null
-  description = "Security group ID's for VPC endpoint."
-}
-
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the resources"


### PR DESCRIPTION
Current implementation would connect the default SG of the VPC to the newly created endpoint. 